### PR TITLE
Rebuild the project using DSMR and MQTT Autodiscovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ clean:
 
 upload:
 	PATH=${PATH} platformio run --target upload --environment esp8266
+
+serial-monitor:
+	PATH=${PATH} platformio device monitor

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# esp8266 DSMR2MQTT
+# ESP8266 P1 Meter to MQTT
+
+[![Build Status](https://travis-ci.org/MarijnKoesen/esp8266_p1meter_mqtt.svg?branch=master)](https://travis-ci.org/MarijnKoesen/esp8266_p1meter_mqtt)
 
 Software for the ESP2866 that sends P1 smart meter data to an MQTT broker (with OTA firmware updates)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/MarijnKoesen/esp8266_p1meter_mqtt.svg?branch=master)](https://travis-ci.org/MarijnKoesen/esp8266_p1meter_mqtt)
 
-Software for the ESP2866 that sends P1 smart meter data to an MQTT broker (with OTA firmware updates)
+Software for the ESP2866 that sends P1 smart meter data to an MQTT broker using Auto Discovery (with OTA firmware updates)
 
 
 ## Connection of the P1 meter to the ESP8266
@@ -22,84 +22,85 @@ Use a 10K resistor in between between DATA (RXD) and RTS.
 ## Data Sent
 
 All metrics are send to their own MQTT topic.
-The ESP8266 sends out to the following MQTT topics:
+
+By default the ESP8266 sends out all data received by the P1 meter, but this is modifieable in the settings.h.
 
 ```
-sensors/power/p1meter/consumption_low_tarif 2209397
-sensors/power/p1meter/consumption_high_tarif 1964962
-sensors/power/p1meter/actual_consumption 313
-sensors/power/p1meter/instant_power_usage 313
-sensors/power/p1meter/instant_power_current 1000
-sensors/power/p1meter/gas_meter_m3 968922
-sensors/power/p1meter/actual_tarif_group 2
-sensors/power/p1meter/short_power_outages 3
-sensors/power/p1meter/long_power_outages 1
-sensors/power/p1meter/short_power_drops 0
-sensors/power/p1meter/short_power_peaks 0
+/**
+ * Define the data we're interested in, as well as the datastructure to
+ * hold the parsed data. This list shows all supported fields, remove
+ * any fields you are not using from the below list to make the parsing
+ * faster, and the data in mqtt smaller. 
+ * Each template argument below results in a field of the same name.
+ */
+using MyData = ParsedData<
+    /* String */ identification,
+    /* String */ p1_version,
+    /* String */ timestamp,
+    /* String */ equipment_id,
+    /* FixedValue */ energy_delivered_tariff1,
+    /* FixedValue */ energy_delivered_tariff2,
+    /* FixedValue */ energy_returned_tariff1,
+    /* FixedValue */ energy_returned_tariff2,
+    /* String */ electricity_tariff,
+    /* FixedValue */ power_delivered,
+    /* FixedValue */ power_returned,
+    /* FixedValue */ electricity_threshold,
+    /* uint8_t */ electricity_switch_position,
+    /* uint32_t */ electricity_failures,
+    /* uint32_t */ electricity_long_failures,
+    /* String */ electricity_failure_log,
+
+    /* uint32_t */ electricity_sags_l1,
+    /* uint32_t */ electricity_sags_l2,
+    /* uint32_t */ electricity_sags_l3,
+    /* uint32_t */ electricity_swells_l1,
+    /* uint32_t */ electricity_swells_l2,
+    /* uint32_t */ electricity_swells_l3,
+    /* String */ message_short,
+    /* String */ message_long,
+
+    /* FixedValue */ voltage_l1,
+    /* FixedValue */ voltage_l2,
+    /* FixedValue */ voltage_l3,
+
+    /* FixedValue */ current_l1,
+    /* FixedValue */ current_l2,
+    /* FixedValue */ current_l3,
+
+    /* FixedValue */ power_delivered_l1,
+    /* FixedValue */ power_delivered_l2,
+    /* FixedValue */ power_delivered_l3,
+    /* FixedValue */ power_returned_l1,
+    /* FixedValue */ power_returned_l2,
+    /* FixedValue */ power_returned_l3,
+
+    /* uint16_t */ gas_device_type,
+    /* String */ gas_equipment_id,
+    /* uint8_t */ gas_valve_position,
+    /* TimestampedFixedValue */ gas_delivered,
+
+    /* uint16_t */ thermal_device_type,
+    /* String */ thermal_equipment_id,
+    /* uint8_t */ thermal_valve_position,
+    /* TimestampedFixedValue */ thermal_delivered,
+
+    /* uint16_t */ water_device_type,
+    /* String */ water_equipment_id,
+    /* uint8_t */ water_valve_position,
+    /* TimestampedFixedValue */ water_delivered,
+
+    /* uint16_t */ slave_device_type,
+    /* String */ slave_equipment_id,
+    /* uint8_t */ slave_valve_position,
+    /* TimestampedFixedValue */ slave_delivered
+>;
 ```
+
 
 ## Home Assistant Configuration
 
-Following is an example definition of the sensors on your config.yaml
-
-```
-- platform: mqtt
-  name: P1 Consumption Low Tarif
-  unit_of_measurement: 'kWh'
-  state_topic: "sensors/power/p1meter/consumption_low_tarif"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Consumption High Tarif
-  unit_of_measurement: 'kWh'
-  state_topic: "sensors/power/p1meter/consumption_high_tarif"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Actual Power Consumption
-  unit_of_measurement: 'kW'
-  state_topic: "sensors/power/p1meter/actual_consumption"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Instant Power Usage
-  unit_of_measurement: 'kW'
-  state_topic: "sensors/power/p1meter/instant_power_usage"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Instant Power Current
-  unit_of_measurement: 'A'
-  state_topic: "sensors/power/p1meter/instant_power_current"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Gas Usage
-  unit_of_measurement: 'm3'
-  state_topic: "sensors/power/p1meter/gas_meter_m3"
-  value_template: "{{ value|float / 1000 }}"
-
-- platform: mqtt
-  name: P1 Actual Tarif Group
-  state_topic: "sensors/power/p1meter/actual_tarif_group"
-
-- platform: mqtt
-  name: P1 Short Power Outages
-  state_topic: "sensors/power/p1meter/short_power_outages"
-
-- platform: mqtt
-  name: P1 Long Power Outages
-  state_topic: "sensors/power/p1meter/long_power_outages"
-
-- platform: mqtt
-  name: P1 Short Power Drops
-  state_topic: "sensors/power/p1meter/short_power_drops"
-
-- platform: mqtt
-  name: P1 Short Power Peaks
-  state_topic: "sensors/power/p1meter/short_power_peaks"
-```
-
+Just enable MQTT AutoDiscovery and set the correct topic in the settings.h and all sensors will be automatically added.
 
 
 ## Thanks to
@@ -107,6 +108,7 @@ Following is an example definition of the sensors on your config.yaml
 This sketch is mostly copied and pasted from several other projects.
 Standing on the heads of giants, big thanks and great respect to the writers and/or creators of:
 
+- https://github.com/matthijskooijman/arduino-dsmr
 - https://github.com/WhoSayIn/esp8266_dsmr2mqtt
 - https://github.com/fliphess/esp8266_p1meter
 - https://github.com/jantenhove/P1-Meter-ESP8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,12 +12,25 @@
 platform = espressif8266
 framework = arduino
 board = d1_mini
-lib_deps = PubSubClient
-;upload_port = /dev/tty*
-;upload_protocol = esptool
+lib_deps = 
+    PubSubClient
+    dsmr
+; upload_port = /dev/tty.wchusbserial1410
+; upload_protocol = esptool
+; monitor_speed = 115200
 upload_protocol = espota
 upload_port = p1meter.local
 upload_flags = --auth=admin
+
+; [env:arduino-mega]
+; platform = atmelavr
+; framework = arduino
+; board = megaatmega2560
+; lib_deps = 
+;     ; PubSubClient
+;     dsmr
+; upload_port = /dev/tty.usbmodem14101
+; monitor_speed = 115200
 
 [platformio]
 src_dir=src

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -1,0 +1,45 @@
+#include <ESP8266WiFi.h>
+#include <PubSubClient.h>
+#include "MqttClient.h"
+#include "settings.h"
+
+long LAST_RECONNECT_ATTEMPT = 0;
+
+MqttClient::MqttClient(WiFiClient &espClient) {
+  this->client = PubSubClient(espClient);
+  this->client.setServer(MQTT_HOST, atoi(MQTT_PORT));
+}
+
+bool MqttClient::sendMessage(String topic, String payload, bool retain) {
+  return client.publish(topic.c_str(), payload.c_str(), retain);
+}
+
+bool MqttClient::sendMessage(String topic, String payload) {
+  return this->sendMessage(topic, payload, false);
+}
+
+void MqttClient::keepAlive() {
+  if (!this->client.connected()) {
+    this->reconnect();
+  } else {
+    this->client.loop();
+  }
+}
+
+bool MqttClient::reconnect() {
+  int tries = 0;
+  int maxTries = 12;
+
+  while (!this->client.connected() && tries < maxTries) {
+    tries++;
+    if (!this->client.connect(HOSTNAME, MQTT_USER, MQTT_PASS)) {
+      delay(5000);
+    }
+  }
+
+  if (tries >= maxTries) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -1,0 +1,21 @@
+#ifndef MQTT_H
+#define MQTT_H
+
+#include <ESP8266WiFi.h>
+#include <PubSubClient.h>
+
+class MqttClient {
+public:
+  MqttClient(WiFiClient &espClient);
+  void keepAlive();
+  // bool sendMessage(const char *topic, char *payload);
+  bool sendMessage(String topic, String payload);
+  bool sendMessage(String topic, String payload, boolean retrain);
+
+private:
+  PubSubClient client;
+
+  bool reconnect();
+};
+
+#endif

--- a/src/arduino_ota.cpp
+++ b/src/arduino_ota.cpp
@@ -1,0 +1,9 @@
+#include "arduino_ota.h"
+#include "settings.h"
+
+void setupOTA() {
+  ArduinoOTA.setPort(8266);
+  ArduinoOTA.setHostname(HOSTNAME);
+  ArduinoOTA.setPassword(OTA_PASSWORD);
+  ArduinoOTA.begin();
+}

--- a/src/arduino_ota.h
+++ b/src/arduino_ota.h
@@ -1,0 +1,8 @@
+#ifndef ARDUINO_OTA_H
+#define ARDUINO_OTA_H
+
+#include <ArduinoOTA.h>
+
+extern void setupOTA();
+
+#endif

--- a/src/esp8266_p1meter_mqtt.ino
+++ b/src/esp8266_p1meter_mqtt.ino
@@ -1,33 +1,82 @@
+#include "settings.h"
 #include <ESP8266WiFi.h>
-#include <ArduinoOTA.h>
-#include <PubSubClient.h>
 #include <SoftwareSerial.h>
 #include <WiFiClient.h>
-
-#include "settings.h"
+#include <dsmr.h>
+#include "MqttClient.h"
+#include "arduino_ota.h"
 
 WiFiClient espClient;
+MqttClient mqttClient(espClient);
+P1Reader reader(&Serial, 2);
 
-PubSubClient mqtt_client(espClient);
+struct MqttPublisher {
+  template <typename Item> void apply(Item &i) {
+    if (i.present()) {
+      String topic = String(MQTT_ROOT_TOPIC) + "/" + String(Item::name);
+      // String value = String(i.val()) + String(Item::unit());
+      String value = String(i.val());
 
-void setup()
-{
-  Serial.begin(BAUD_RATE);
-
-  WiFi.begin(WIFI_SSID, WIFI_PASS);
-
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-    //Serial.print(".");
+      mqttClient.sendMessage(topic, value);
+    }
   }
+};
 
-  setup_ota();
+struct AutoDiscoveryPublisher {
+  template <typename Item> void apply(Item &i) {
+    String topic = String(MQTT_AUTODISCOVERY_TOPIC) + String("/") + String(Item::name) + String("/config");
+    String value = String(
+      "{"
+        "\"name\": \"P1 ") + String(Item::name) + String("\","
+        "\"unique_id\": \"") + String(MQTT_DEVICE_ID) + String("_") + String(Item::name) + String("\","
+        "\"unit_of_measurement\": \"") + String(Item::unit()) + String("\","
+        "\"state_topic\": \"") + String(MQTT_ROOT_TOPIC) + String("/") + String(Item::name) + String("\","
+        "\"force_update\": true,"
+        "\"device\": {"
+          "\"identifiers\": ["
+            "\"") + String(MQTT_DEVICE_ID) + String("\""
+          "],"
+          "\"name\": \"P1 Power Meter\""
+        "}"
+      "}"
+      );
 
-  mqtt_client.setServer(MQTT_HOST, atoi(MQTT_PORT));
+    // Retain these messages, because we don't want to loose our devices
+    mqttClient.sendMessage(topic, value, true);
+  }
+};
+
+void setup() {
+  Serial.begin(BAUD_RATE);
+  wifiKeepAlive();
+  mqttClient.keepAlive();
+
+  setupOTA();
+  reader.enable(false);
+
+  MyData data;
+  data.applyEach(AutoDiscoveryPublisher());
 }
 
-void loop()
-{
+void loop() {
+  wifiKeepAlive();
+  mqttClient.keepAlive();
+  ArduinoOTA.handle();
+
+  if (reader.loop()) {
+    MyData data;
+    String err;
+    if (reader.parse(&data, &err)) {
+      // Parse succesful, send to mqtt
+      data.applyEach(MqttPublisher());
+    } else {
+      // Parser error, print error
+      // Serial.println(err);
+    }
+  }
+}
+
+void wifiKeepAlive() {
   if (WiFi.status() != WL_CONNECTED) {
     WiFi.begin(WIFI_SSID, WIFI_PASS);
 
@@ -35,338 +84,4 @@ void loop()
       delay(500);
     }
   }
-
-  ArduinoOTA.handle();
-
-  if (!mqtt_client.connected())
-  {
-    long now = millis();
-
-    if (now - LAST_RECONNECT_ATTEMPT > 5000)
-    {
-      LAST_RECONNECT_ATTEMPT = now;
-
-      if (mqtt_reconnect())
-      {
-        LAST_RECONNECT_ATTEMPT = 0;
-      }
-    }
-  }
-  else
-  {
-    mqtt_client.loop();
-  }
-
-  read_p1_serial();
-}
-
-
-void send_mqtt_message(const char *topic, char *payload)
-{
-  bool result = mqtt_client.publish(topic, payload, false);
-}
-
-bool mqtt_reconnect()
-{
-  int MQTT_RECONNECT_RETRIES = 0;
-
-  while (!mqtt_client.connected() && MQTT_RECONNECT_RETRIES < MQTT_MAX_RECONNECT_TRIES)
-  {
-    MQTT_RECONNECT_RETRIES++;
-    if (mqtt_client.connect(HOSTNAME, MQTT_USER, MQTT_PASS))
-    {
-      char *message = new char[16 + strlen(HOSTNAME) + 1];
-      strcpy(message, "p1 meter alive: ");
-      strcat(message, HOSTNAME);
-      mqtt_client.publish("hass/status", message);
-
-      // Serial.printf("MQTT root topic: %s\n", MQTT_ROOT_TOPIC);
-    }
-    else
-    {
-//      Serial.print(F("MQTT Connection failed: rc="));
-//      Serial.println(mqtt_client.state());
-//      Serial.println(F(" Retrying in 5 seconds"));
-//      Serial.println("");
-
-      delay(5000);
-    }
-  }
-
-  if (MQTT_RECONNECT_RETRIES >= MQTT_MAX_RECONNECT_TRIES)
-  {
-    // Serial.printf("*** MQTT connection failed, giving up after %d tries ...\n", MQTT_RECONNECT_RETRIES);
-    return false;
-  }
-
-  return true;
-}
-
-void send_metric(String name, long metric)
-{
-  // if (metric > 0) {
-//    Serial.print(F("Sending metric to broker: "));
-//    Serial.print(name);
-//    Serial.print(F("="));
-//    Serial.println(metric);
-
-    char output[10];
-    ltoa(metric, output, sizeof(output));
-
-    String topic = String(MQTT_ROOT_TOPIC) + "/" + name;
-    send_mqtt_message(topic.c_str(), output);
-  // }
-}
-
-void send_data_to_broker()
-{
-  send_metric("consumption_low_tarif", CONSUMPTION_LOW_TARIF);
-  send_metric("consumption_high_tarif", CONSUMPTION_HIGH_TARIF);
-  send_metric("actual_consumption", ACTUAL_CONSUMPTION);
-  send_metric("actual_returned", ACTUAL_RETURNED);
-  send_metric("instant_power_usage", INSTANT_POWER_USAGE);
-  send_metric("instant_power_current", INSTANT_POWER_CURRENT);
-  send_metric("gas_meter_m3", GAS_METER_M3);
-
-  send_metric("actual_tarif_group", ACTUAL_TARIF);
-  send_metric("short_power_outages", SHORT_POWER_OUTAGES);
-  send_metric("long_power_outages", LONG_POWER_OUTAGES);
-  send_metric("short_power_drops", SHORT_POWER_DROPS);
-  send_metric("short_power_peaks", SHORT_POWER_PEAKS);
-}
-
-unsigned int CRC16(unsigned int crc, unsigned char *buf, int len)
-{
-  for (int pos = 0; pos < len; pos++) {
-    crc ^= (unsigned int)buf[pos];
-
-    for (int i = 8; i != 0; i--) {
-      if ((crc & 0x0001) != 0) {
-        crc >>= 1;
-        crc ^= 0xA001;
-      } else {
-        crc >>= 1;
-      }
-    }
-  }
-
-  return crc;
-}
-
-bool isNumber(char *res, int len)
-{
-  for (int i = 0; i < len; i++) {
-    if (((res[i] < '0') || (res[i] > '9')) && (res[i] != '.' && res[i] != 0)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-int FindCharInArrayRev(char array[], char c, int len)
-{
-  for (int i = len - 1; i >= 0; i--) {
-    if (array[i] == c) {
-      return i;
-    }
-  }
-
-  return -1;
-}
-
-long getValue(char *buffer, int maxlen, char startchar, char endchar)
-{
-  int s = FindCharInArrayRev(buffer, startchar, maxlen - 2);
-  int l = FindCharInArrayRev(buffer, endchar, maxlen - 2) - s - 1;
-
-  char res[16];
-  memset(res, 0, sizeof(res));
-
-  if (strncpy(res, buffer + s + 1, l))
-  {
-    if (endchar == '*')
-    {
-      if (isNumber(res, l))
-        return (1000 * atof(res));
-    }
-    else if (endchar == ')')
-    {
-      if (isNumber(res, l))
-        return atof(res);
-    }
-  }
-  return 0;
-}
-
-bool decode_telegram(int len)
-{
-  int startChar = FindCharInArrayRev(telegram, '/', len);
-  int endChar = FindCharInArrayRev(telegram, '!', len);
-  bool validCRCFound = false;
-
-  /*
-  for (int cnt = 0; cnt < len; cnt++)
-    Serial.print(telegram[cnt]);
-  */
-  
-  if (startChar >= 0)
-  {
-    currentCRC = CRC16(0x0000, (unsigned char *) telegram + startChar, len - startChar);
-  }
-  else if (endChar >= 0)
-  {
-    currentCRC = CRC16(currentCRC, (unsigned char*)telegram + endChar, 1);
-
-    char messageCRC[5];
-    strncpy(messageCRC, telegram + endChar + 1, 4);
-
-    messageCRC[4] = 0;
-    validCRCFound = (strtol(messageCRC, NULL, 16) == currentCRC);
-
-//    if (validCRCFound)
-//      Serial.println(F("CRC Valid!"));
-//    else
-//      Serial.println(F("CRC Invalid!"));
-
-    currentCRC = 0;
-  }
-  else
-  {
-    currentCRC = CRC16(currentCRC, (unsigned char*) telegram, len);
-  }
-
-  if (strncmp(telegram, "1-0:1.8.1", strlen("1-0:1.8.1")) == 0)
-  {
-    CONSUMPTION_LOW_TARIF = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "1-0:1.8.2", strlen("1-0:1.8.2")) == 0)
-  {
-    CONSUMPTION_HIGH_TARIF = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "1-0:1.7.0", strlen("1-0:1.7.0")) == 0)
-  {
-    ACTUAL_CONSUMPTION = getValue(telegram, len, '(', '*');
-  }
-  if (strncmp(telegram, "1-0:2.7.0", strlen("1-0:2.7.0")) == 0)
-  {
-    ACTUAL_RETURNED = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "1-0:21.7.0", strlen("1-0:21.7.0")) == 0)
-  {
-    INSTANT_POWER_USAGE = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "1-0:31.7.0", strlen("1-0:31.7.0")) == 0)
-  {
-    INSTANT_POWER_CURRENT = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "0-1:24.2.1", strlen("0-1:24.2.1")) == 0)
-  {
-    GAS_METER_M3 = getValue(telegram, len, '(', '*');
-  }
-
-  if (strncmp(telegram, "0-0:96.14.0", strlen("0-0:96.14.0")) == 0)
-  {
-    ACTUAL_TARIF = getValue(telegram, len, '(', ')');
-  }
-
-  if (strncmp(telegram, "0-0:96.7.21", strlen("0-0:96.7.21")) == 0)
-  {
-    SHORT_POWER_OUTAGES = getValue(telegram, len, '(', ')');
-  }
-
-  if (strncmp(telegram, "0-0:96.7.9", strlen("0-0:96.7.9")) == 0)
-  {
-    LONG_POWER_OUTAGES = getValue(telegram, len, '(', ')');
-  }
-
-  if (strncmp(telegram, "1-0:32.32.0", strlen("1-0:32.32.0")) == 0)
-  {
-    SHORT_POWER_DROPS = getValue(telegram, len, '(', ')');
-  }
-
-  if (strncmp(telegram, "1-0:32.36.0", strlen("1-0:32.36.0")) == 0)
-  {
-    SHORT_POWER_PEAKS = getValue(telegram, len, '(', ')');
-  }
-
-  return validCRCFound;
-}
-
-void read_p1_serial()
-{
-  if (Serial.available())
-  {
-    memset(telegram, 0, sizeof(telegram));
-
-    while (Serial.available())
-    {
-      ESP.wdtDisable();
-      int len = Serial.readBytesUntil('\n', telegram, P1_MAXLINELENGTH);
-      ESP.wdtEnable(1);
-
-      telegram[len] = '\n';
-      telegram[len + 1] = 0;
-
-      String topic = String(MQTT_ROOT_TOPIC) + "/raw_log";
-      String msg = String(telegram);
-      msg.trim();
-      send_mqtt_message(topic.c_str(), (char*)(msg.c_str()));
-
-      yield();
-
-      bool result = decode_telegram(len + 1);
-      if (result)
-        send_data_to_broker();
-    }
-  }
-}
-
-void setup_ota()
-{
-  //Serial.println(F("Arduino OTA activated."));
-
-  ArduinoOTA.setPort(8266);
-
-  ArduinoOTA.setHostname(HOSTNAME);
-  ArduinoOTA.setPassword(OTA_PASSWORD);
-
-  ArduinoOTA.onStart([]()
-  {
-//    Serial.println(F("Arduino OTA: Start"));
-  });
-
-  ArduinoOTA.onEnd([]()
-  {
-//    Serial.println(F("Arduino OTA: End (Running reboot)"));
-  });
-
-  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total)
-  {
-//    Serial.printf("Arduino OTA Progress: %u%%\r", (progress / (total / 100)));
-  });
-
-//  ArduinoOTA.onError([](ota_error_t error)
-//  {
-//    
-//    Serial.printf("Arduino OTA Error[%u]: ", error);
-//    if (error == OTA_AUTH_ERROR)
-//      Serial.println(F("Arduino OTA: Auth Failed"));
-//    else if (error == OTA_BEGIN_ERROR)
-//      Serial.println(F("Arduino OTA: Begin Failed"));
-//    else if (error == OTA_CONNECT_ERROR)
-//      Serial.println(F("Arduino OTA: Connect Failed"));
-//    else if (error == OTA_RECEIVE_ERROR)
-//      Serial.println(F("Arduino OTA: Receive Failed"));
-//    else if (error == OTA_END_ERROR)
-//      Serial.println(F("Arduino OTA: End Failed"));
-//  });
-
-  ArduinoOTA.begin();
-//  Serial.println(F("Arduino OTA finished"));
 }

--- a/src/settings.h-dist
+++ b/src/settings.h-dist
@@ -1,43 +1,94 @@
-#define BAUD_RATE 115200
+#ifndef SETTINGS_H
+#define SETTINGS_H
 
+#include <dsmr.h>
+
+#define BAUD_RATE 115200
 #define P1_SERIAL_RX D5
 
-#define P1_MAXLINELENGTH 1024
-
 #define HOSTNAME "p1meter"
-
 #define OTA_PASSWORD "admin"
 
-#define WIFI_TIMEOUT 30000
+#define MQTT_AUTODISCOVERY_TOPIC "homeassistant/sensor/p1meter"
+#define MQTT_DEVICE_ID "p1meter"
+#define MQTT_ROOT_TOPIC "sensors/p1"
 
-#define MQTT_MAX_RECONNECT_TRIES 100
+#define WIFI_SSID "CHANGE_WITH_YOUR_WIFI_SSID"
+#define WIFI_PASS "CHANGE_WITH_YOUR_WIFI_PASSWORD"
 
-#define MQTT_ROOT_TOPIC "sensors/power/p1meter"
+#define MQTT_HOST "CHANGE_WITH_YOUR_MQTT_BROKER_HOST"
+#define MQTT_PORT "CHANGE_WITH_YOUR_MQTT_PORT_(THE_DEFAULT_IS_1883)"
+#define MQTT_USER "CHANGE_WITH_YOUR_MQTT_USER"
+#define MQTT_PASS "CHANGE_WITH_YOUR_MQTT_PASSWORD"
 
-long LAST_RECONNECT_ATTEMPT = 0;
+/**
+ * Define the data we're interested in, as well as the datastructure to
+ * hold the parsed data. This list shows all supported fields, remove
+ * any fields you are not using from the below list to make the parsing
+ * faster, and the data in mqtt smaller. 
+ * Each template argument below results in a field of the same name.
+ */
+using MyData = ParsedData<
+    /* String */ identification,
+    /* String */ p1_version,
+    /* String */ timestamp,
+    /* String */ equipment_id,
+    /* FixedValue */ energy_delivered_tariff1,
+    /* FixedValue */ energy_delivered_tariff2,
+    /* FixedValue */ energy_returned_tariff1,
+    /* FixedValue */ energy_returned_tariff2,
+    /* String */ electricity_tariff,
+    /* FixedValue */ power_delivered,
+    /* FixedValue */ power_returned,
+    /* FixedValue */ electricity_threshold,
+    /* uint8_t */ electricity_switch_position,
+    /* uint32_t */ electricity_failures,
+    /* uint32_t */ electricity_long_failures,
+    /* String */ electricity_failure_log,
 
-char WIFI_SSID[32] = "CHANGE_WITH_YOUR_WIFI_SSID";
-char WIFI_PASS[32] = "CHANGE_WITH_YOUR_WIFI_PASSWORD";
+    /* uint32_t */ electricity_sags_l1,
+    /* uint32_t */ electricity_sags_l2,
+    /* uint32_t */ electricity_sags_l3,
+    /* uint32_t */ electricity_swells_l1,
+    /* uint32_t */ electricity_swells_l2,
+    /* uint32_t */ electricity_swells_l3,
+    /* String */ message_short,
+    /* String */ message_long,
 
-char MQTT_HOST[64] = "CHANGE_WITH_YOUR_MQTT_BROKER_HOST";
-char MQTT_PORT[6]  = "CHANGE_WITH_YOUR_MQTT_BROKER_PORT(USUALLY_1883)";
-char MQTT_USER[32] = "CHANGE_WITH_YOUR_MQTT_USER";
-char MQTT_PASS[32] = "CHANGE_WITH_YOUR_MQTT_PASSWORD";
+    /* FixedValue */ voltage_l1,
+    /* FixedValue */ voltage_l2,
+    /* FixedValue */ voltage_l3,
 
-char telegram[P1_MAXLINELENGTH];
+    /* FixedValue */ current_l1,
+    /* FixedValue */ current_l2,
+    /* FixedValue */ current_l3,
 
-long CONSUMPTION_LOW_TARIF;
-long CONSUMPTION_HIGH_TARIF;
-long ACTUAL_CONSUMPTION;
-long ACTUAL_RETURNED;
-long INSTANT_POWER_CURRENT;
-long INSTANT_POWER_USAGE;
-long GAS_METER_M3;
+    /* FixedValue */ power_delivered_l1,
+    /* FixedValue */ power_delivered_l2,
+    /* FixedValue */ power_delivered_l3,
+    /* FixedValue */ power_returned_l1,
+    /* FixedValue */ power_returned_l2,
+    /* FixedValue */ power_returned_l3,
 
-long ACTUAL_TARIF;
-long SHORT_POWER_OUTAGES;
-long LONG_POWER_OUTAGES;
-long SHORT_POWER_DROPS;
-long SHORT_POWER_PEAKS;
+    /* uint16_t */ gas_device_type,
+    /* String */ gas_equipment_id,
+    /* uint8_t */ gas_valve_position,
+    /* TimestampedFixedValue */ gas_delivered,
 
-unsigned int currentCRC = 0;
+    /* uint16_t */ thermal_device_type,
+    /* String */ thermal_equipment_id,
+    /* uint8_t */ thermal_valve_position,
+    /* TimestampedFixedValue */ thermal_delivered,
+
+    /* uint16_t */ water_device_type,
+    /* String */ water_equipment_id,
+    /* uint8_t */ water_valve_position,
+    /* TimestampedFixedValue */ water_delivered,
+
+    /* uint16_t */ slave_device_type,
+    /* String */ slave_equipment_id,
+    /* uint8_t */ slave_valve_position,
+    /* TimestampedFixedValue */ slave_delivered
+>;
+
+#endif


### PR DESCRIPTION
The project is rebuilt with the DSMR library, adding
MQTT and autodiscovery on top.

By default all data from the P1 meter is sent to MQTT,
and all sensors are added automatically in HomeAssistant
using the MQTT auto discovery.

I wanted to read more data, especially the returned tariffs
and some other things, like voltage and current. But the
original code didn't allow this. Using the autodiscovery
you're getting a very easy integration, no need to edit
YAML files, and no need to restart HomeAssistant to are
or remove sensors.